### PR TITLE
Fix type error in retryHandler with ConnectException

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -267,7 +267,7 @@ class Client
     private function getRetryHandler(): Closure
     {
         return function ($retries, ?RequestInterface $request, ?ResponseInterface $response,
-            ?RequestException $exception) {
+            ?GuzzleException $exception) {
             if (!$response || $response->getStatusCode() > 500 || ($exception && $exception instanceof ConnectException))
                 return false;
 


### PR DESCRIPTION
Since guzzle 7.0 the ConnectException no longer extends RequestException. 
This leads to type errors in the retry handler in case of connection exceptions.
Change the signature to GuzzleException to cover all possible cases